### PR TITLE
feat: add dockerized build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM gradle:focal as build
+
+WORKDIR 	/app
+COPY		. .
+RUN		gradle clean
+RUN		gradle build
+
+
+FROM scratch
+COPY --from=build /app/lib/build/libs/* .
+COPY --from=build /app/lib/build/deps/* .

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+DOCKER_BUILDKIT=1 docker build --file Dockerfile --output build .


### PR DESCRIPTION
This MR adds the ability to build the library with a dockerized environment.

Simply just run `./build.sh` and it puts all *.jar files in a ./build directory at the root of the repo